### PR TITLE
Fixed typo in Bucket Equation

### DIFF
--- a/2014_15/3_bucket_equation/tex_source/3_bucket_equation.tex
+++ b/2014_15/3_bucket_equation/tex_source/3_bucket_equation.tex
@@ -136,7 +136,7 @@ inputis that the solution kind of chases the input with a timescale
 set by $\tau$, that is for very small $\tau$ is chases it quickly, so
 it is close to the input, but for large $\tau$ it lags behind it and
 smooths it out. This is sometimes described by saying that it
-\textsl{filters} the inout. There is an illustration in
+\textsl{filters} the input. There is an illustration in
 Fig.~\ref{chasing}.
 
 \begin{figure}


### PR DESCRIPTION
"inout"->"input" under Variable Input
